### PR TITLE
SelectStatement interpolates optional where fragment

### DIFF
--- a/lib/message_store/postgres/get.rb
+++ b/lib/message_store/postgres/get.rb
@@ -3,19 +3,19 @@ module MessageStore
     class Get
       include MessageStore::Get
 
-      initializer :batch_size
+      initializer :batch_size, :condition
 
       dependency :session, Session
 
-      def self.build(batch_size: nil, session: nil)
-        new(batch_size).tap do |instance|
+      def self.build(batch_size: nil, session: nil, condition: nil)
+        new(batch_size, condition).tap do |instance|
           instance.configure(session: session)
         end
       end
 
-      def self.configure(receiver, attr_name: nil, position: nil, batch_size: nil, session: nil)
+      def self.configure(receiver, attr_name: nil, position: nil, batch_size: nil, condition: nil, session: nil)
         attr_name ||= :get
-        instance = build(batch_size: batch_size, session: session)
+        instance = build(batch_size: batch_size, condition: condition, session: session)
         receiver.public_send "#{attr_name}=", instance
       end
 
@@ -23,8 +23,8 @@ module MessageStore
         Session.configure self, session: session
       end
 
-      def self.call(stream_name, position: nil, batch_size: nil, session: nil)
-        instance = build(batch_size: batch_size, session: session)
+      def self.call(stream_name, position: nil, batch_size: nil, condition: nil,  session: nil)
+        instance = build(batch_size: batch_size, condition: condition, session: session)
         instance.(stream_name, position: position)
       end
 
@@ -44,7 +44,9 @@ module MessageStore
       def get_records(stream_name, position)
         logger.trace { "Getting records (Stream: #{stream_name}, Position: #{position.inspect}, Batch Size: #{batch_size.inspect})" }
 
-        select_statement = SelectStatement.build(stream_name, position: position, batch_size: batch_size)
+        where_fragment = self.condition
+
+        select_statement = SelectStatement.build(stream_name, position: position, batch_size: batch_size, where_fragment: where_fragment)
 
         records = session.execute(select_statement.sql)
 

--- a/lib/message_store/postgres/get.rb
+++ b/lib/message_store/postgres/get.rb
@@ -42,7 +42,7 @@ module MessageStore
       end
 
       def get_records(stream_name, position)
-        logger.trace { "Getting records (Stream: #{stream_name}, Position: #{position.inspect}, Batch Size: #{batch_size.inspect})" }
+        logger.trace { "Getting records (Stream: #{stream_name}, Position: #{position.inspect}, Batch Size: #{batch_size.inspect}, Condition: #{condition || '(none)'})" }
 
         where_fragment = self.condition
 
@@ -50,7 +50,7 @@ module MessageStore
 
         records = session.execute(select_statement.sql)
 
-        logger.debug { "Finished getting records (Count: #{records.ntuples}, Stream: #{stream_name}, Position: #{position.inspect}, Batch Size: #{batch_size.inspect})" }
+        logger.debug { "Finished getting records (Count: #{records.ntuples}, Stream: #{stream_name}, Position: #{position.inspect}, Batch Size: #{batch_size.inspect}, Condition: #{condition || '(none)'})" }
 
         records
       end

--- a/lib/message_store/postgres/get.rb
+++ b/lib/message_store/postgres/get.rb
@@ -46,7 +46,7 @@ module MessageStore
 
         where_fragment = self.condition
 
-        select_statement = SelectStatement.build(stream_name, position: position, batch_size: batch_size, where_fragment: where_fragment)
+        select_statement = SelectStatement.build(stream_name, position: position, batch_size: batch_size, condition: condition)
 
         records = session.execute(select_statement.sql)
 

--- a/lib/message_store/postgres/get/select_statement.rb
+++ b/lib/message_store/postgres/get/select_statement.rb
@@ -27,7 +27,7 @@ module MessageStore
         end
 
         def sql
-          logger.trace(tag: :sql) { "Composing select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
+          logger.trace(tag: :sql) { "Composing select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size}, Condition: #{condition || '(none)'})" }
 
           formatted_where_clause = where_clause.each_line.to_a.join("  ")
 
@@ -52,7 +52,7 @@ module MessageStore
             ;
           SQL
 
-          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
+          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size}, Condition: #{condition || '(none)'})" }
           logger.debug(tags: [:data, :sql]) { "Statement: #{statement}" }
 
           statement

--- a/lib/message_store/postgres/get/select_statement.rb
+++ b/lib/message_store/postgres/get/select_statement.rb
@@ -4,7 +4,7 @@ module MessageStore
       class SelectStatement
         include Log::Dependency
 
-        initializer :stream_name, w(:position), w(:batch_size), :where_fragment
+        initializer :stream_name, w(:position), w(:batch_size), :condition
 
         def position
           @position ||= Defaults.position
@@ -22,8 +22,8 @@ module MessageStore
           is_category_stream ||= StreamName.category?(stream_name)
         end
 
-        def self.build(stream_name, position: nil, batch_size: nil, where_fragment: nil)
-          new(stream_name, position, batch_size, where_fragment)
+        def self.build(stream_name, position: nil, batch_size: nil, condition: nil)
+          new(stream_name, position, batch_size, condition)
         end
 
         def sql
@@ -64,8 +64,8 @@ module MessageStore
             #{position_field} >= #{position}
           SQL
 
-          unless where_fragment.nil?
-            clause << " AND\n(#{where_fragment})"
+          unless condition.nil?
+            clause << " AND\n(#{condition})"
           end
 
           clause

--- a/lib/message_store/postgres/get/select_statement.rb
+++ b/lib/message_store/postgres/get/select_statement.rb
@@ -60,7 +60,7 @@ module MessageStore
 
         def where_clause
           clause = <<~SQL.chomp
-            #{where_clause_field} = '#{stream_name}' AND
+            #{discriminator_field} = '#{stream_name}' AND
             #{position_field} >= #{position}
           SQL
 
@@ -71,7 +71,7 @@ module MessageStore
           clause
         end
 
-        def where_clause_field
+        def discriminator_field
           unless category_stream?
             'stream_name'
           else

--- a/lib/message_store/postgres/read.rb
+++ b/lib/message_store/postgres/read.rb
@@ -3,9 +3,9 @@ module MessageStore
     class Read
       include MessageStore::Read
 
-      def configure(session: nil)
+      def configure(session: nil, condition: nil)
         Iterator.configure(self, stream_name, position: position)
-        Get.configure(self.iterator, batch_size: batch_size, session: session)
+        Get.configure(self.iterator, batch_size: batch_size, condition: condition, session: session)
       end
     end
   end

--- a/test/automated/get/condition.rb
+++ b/test/automated/get/condition.rb
@@ -1,0 +1,19 @@
+require_relative '../automated_init'
+
+context "Get" do
+  context "Condition" do
+    stream_name = Controls::Put.(instances: 3)
+
+    condition = 'position = 0 OR position = 2'
+
+    messages = Get.(stream_name, batch_size: 3, condition: condition)
+
+    message_positions = messages.map do |message|
+      message.position
+    end
+
+    test "Returns messages that meet the condition" do
+      assert(message_positions == [0, 2])
+    end
+  end
+end

--- a/test/automated/read/condition.rb
+++ b/test/automated/read/condition.rb
@@ -1,0 +1,19 @@
+require_relative '../automated_init'
+
+context "Read" do
+  context "Condition" do
+    stream_name = Controls::Put.(instances: 3)
+
+    condition = 'position = 0'
+
+    message_count = 0
+
+    Read.(stream_name, condition: condition) do
+      message_count += 1
+    end
+
+    test "Reads messages that meet condition" do
+      assert(message_count == 1)
+    end
+  end
+end

--- a/test/automated/select_statement/condition.rb
+++ b/test/automated/select_statement/condition.rb
@@ -1,12 +1,12 @@
 require_relative '../automated_init'
 
 context "Select Statement" do
-  context "Where Fragment" do
+  context "Condition" do
     stream_name = Controls::StreamName.example
 
-    where_fragment = '1 = 1'
+    condition = '1 = 1'
 
-    select_statement = Get::SelectStatement.build(stream_name, where_fragment: where_fragment)
+    select_statement = Get::SelectStatement.build(stream_name, condition: condition)
 
     sql = select_statement.sql
     sql.gsub!(/\s+/, ' ')
@@ -20,8 +20,8 @@ context "Select Statement" do
         assert(sql.include? 'position >=')
       end
 
-      test "Includes where fragment encased in parentheses" do
-        assert(sql.include? "AND (#{where_fragment})")
+      test "Includes condition encased in parentheses" do
+        assert(sql.include? "AND (#{condition})")
       end
     end
   end

--- a/test/automated/select_statement/where_fragment.rb
+++ b/test/automated/select_statement/where_fragment.rb
@@ -1,0 +1,28 @@
+require_relative '../automated_init'
+
+context "Select Statement" do
+  context "Where Fragment" do
+    stream_name = Controls::StreamName.example
+
+    where_fragment = '1 = 1'
+
+    select_statement = Get::SelectStatement.build(stream_name, where_fragment: where_fragment)
+
+    sql = select_statement.sql
+    sql.gsub!(/\s+/, ' ')
+
+    context "Where Clause" do
+      test "Filters on stream name" do
+        assert(sql.include? 'WHERE stream_name =')
+      end
+
+      test "Filters on position" do
+        assert(sql.include? 'position >=')
+      end
+
+      test "Includes where fragment encased in parentheses" do
+        assert(sql.include? "AND (#{where_fragment})")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is part of a slightly broader effort to allow for additional where fragments to be specified on postgres readers. This PR only covers the changes to `MessageStore::Postgres::Get::SelectStatement`, which is where the actual logic to interpolate where fragments goes. My suspicion is that we'll be better off by reviewing this small batch of changes first.

The goal eventually is to allow for readers that can filter out some of the messages based on customizable criteria, for instance:

- Read only the initial messages of each stream in a category. This allows us to iterate through each stream of a category, which is necessary under certain circumstances: for instance, a nightly job that iterates through each account, sending an email to the associated customer if their account balance is low. More relevant to our current work, we might need to iterate through all open sales, canceling each one that has been abandoned by the customer.
- Read all messages of a given type, for instance all the Withdrawn events of a category. This is analogous to EventStore's "by type" projection. I can see this being useful in a pub/sub situation where a subscriber is only listening for one specific message type.
- Parallel processing. For instance, one could start four consumers: the first reads every fourth message starting from global position zero, the second reads every fourth message starting from global position 1, etc.