### PR TITLE
Database setup scripts are more robust

### DIFF
--- a/database/install.sh
+++ b/database/install.sh
@@ -28,7 +28,7 @@ echo
 function create-user {
   echo "Database user is: $user"
 
-  user_exists=`psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$user'"`
+  user_exists=`psql postgres -qtAXc "SELECT 1 FROM pg_roles WHERE rolname='$user'"`
 
   if [ "$user_exists" = "1" ]; then
     echo "Database user \"$user\" was previously created. Not creating again."

--- a/database/uninstall.sh
+++ b/database/uninstall.sh
@@ -28,7 +28,7 @@ echo
 function delete-user {
   echo "Database user is: $user"
 
-  user_exists=`psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$user'"`
+  user_exists=`psql postgres -qtAXc "SELECT 1 FROM pg_roles WHERE rolname='$user'"`
 
   if [ "$user_exists" = "1" ]; then
     echo "Deleting database user \"$user\"..."
@@ -43,7 +43,7 @@ function delete-user {
 function delete-database {
   echo "Database name is: $database"
 
-  database_exists=`psql postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$database'"`
+  database_exists=`psql postgres -qtAXc "SELECT 1 FROM pg_database WHERE datname='$database'"`
 
   if [ "$database_exists" = "1" ]; then
     echo "Deleting database \"$database\"..."


### PR DESCRIPTION
The scripts rely on comparing the exact output of `psql` commands to check for the existence of objects in the database.

The psql output can be impacted by user preferences in their `.psqlrc` file, breaking the scripts.

To reproduce, add the following line to `~/.psqlrc`:

```
\pset format wrapped
```

The install/uninstall scripts will now fail to find existing objects.

The -q flag silences all output other than the query result.
The -X flag ignores the user's .psqlrc so that output is more deterministic.