### PR TITLE
Remove redundant indexes

### DIFF
--- a/database/indexes/messages-category.sql
+++ b/database/indexes/messages-category.sql
@@ -1,1 +1,0 @@
-CREATE INDEX CONCURRENTLY "messages_category_idx" ON "public"."messages" USING btree(category(stream_name) COLLATE "default" "pg_catalog"."text_ops" ASC NULLS LAST);

--- a/database/indexes/messages-stream-name.sql
+++ b/database/indexes/messages-stream-name.sql
@@ -1,1 +1,0 @@
-CREATE INDEX CONCURRENTLY "messages_stream_name_idx" ON "public"."messages" USING btree(stream_name COLLATE "default" "pg_catalog"."text_ops" ASC NULLS LAST);

--- a/database/install.sh
+++ b/database/install.sh
@@ -86,10 +86,6 @@ function create-indexes {
   psql $database -f $base/indexes/messages-id.sql
   echo "messages_category_global_position_idx"
   psql $database -f $base/indexes/messages-category-global-position.sql
-  echo "messages_category_idx"
-  psql $database -f $base/indexes/messages-category.sql
-  echo "messages_stream_name_idx"
-  psql $database -f $base/indexes/messages-stream-name.sql
   echo "messages_stream_name_position_uniq_idx"
   psql $database -f $base/indexes/messages-stream-name-position-uniq.sql
   echo


### PR DESCRIPTION
There are already multicolumn indexes on stream,position and
category/global_position. Those cover the two most common queries.

PostgreSQL can still use those indexes for queries on stream or category
alone, since they are the leftmost column:

> A multicolumn B-tree index can be used with query conditions that
involve any subset of the index's columns, but the index is most
efficient when there are constraints on the leading (leftmost) columns.
The exact rule is that equality constraints on leading columns, plus any
inequality constraints on the first column that does not have an
equality constraint, will be used to limit the portion of the index that
is scanned

https://www.postgresql.org/docs/9.6/static/indexes-multicolumn.html

The redundant single column indexes may have a slight performance
advantage over the multi-column indexes for queries that only use the
first column (since the indexes are smaller), ~~but those queries are
likely rare, and probably not~~ and may not be worth the cost of the
redundant indexes (disk space, and slower INSERTs).

UPDATE: I realized the `stream_version` function relies on querying the
table with only the `stream_name` specified, so it is *not* a rare
query. I still think the multi-column index will be sufficient to fulfill
this query and any degradation in performance compared to the single
column index would be made up in savings on the INSERT. That said,
I do not have a production eventide database with the necessary load
to validate this assumption.