### PR TITLE
use expanded table output when listing messages from postgres

### DIFF
--- a/database/list-messages.sh
+++ b/database/list-messages.sh
@@ -46,7 +46,7 @@ fi
 echo
 
 if [ -z $stream_name ]; then
-  psql $database -c "SELECT * FROM $table"
+  psql $database -x -c "SELECT * FROM $table"
 else
-  psql $database -c "SELECT * FROM $table WHERE stream_name = '$stream_name'"
+  psql $database -x -c "SELECT * FROM $table WHERE stream_name = '$stream_name'"
 fi


### PR DESCRIPTION
This results in better output when using terminals with limited width.  The expanded table output is columnar and looks like this:

```
Listing Messages
= = =

(DATABASE_USER is not set)
Database user is: message_store
(DATABASE_NAME is not set)
Database name is: message_store
(TABLE_NAME is not set)
Table name is: messages
(STREAM_NAME is not set)

-[ RECORD 1 ]---+-----------------------------------------------------------------
id              | 36a7543b-6e00-4791-a52c-4566f5fb7631
stream_name     | someStream-5223c2a9-8ae4-4db4-a232-17aa4ccb8c33
type            | SomeMessage
position        | 0
global_position | 1
data            | {"someAttribute": "some value", "otherAttribute": "other value"}
metadata        |
time            | 2018-04-24 20:39:42.920011
```