### PR TITLE
Fix Get and Get::Last select_statement position type

### DIFF
--- a/lib/message_store/postgres/get/last/select_statement.rb
+++ b/lib/message_store/postgres/get/last/select_statement.rb
@@ -18,7 +18,7 @@ module MessageStore
               SELECT
                 id::varchar,
                 stream_name::varchar,
-                position::int,
+                position::bigint,
                 type::varchar,
                 global_position::bigint,
                 data::varchar,

--- a/lib/message_store/postgres/get/select_statement.rb
+++ b/lib/message_store/postgres/get/select_statement.rb
@@ -35,7 +35,7 @@ module MessageStore
             SELECT
               id::varchar,
               stream_name::varchar,
-              position::int,
+              position::bigint,
               type::varchar,
               global_position::bigint,
               data::varchar,


### PR DESCRIPTION
`position` in the select query was `int`, but in the table is `bigint`. Casting to `int` a `bigint` (`position` greater than `2147483647`) will raise a **Postgres** error: `ERROR:  integer out of range`.

This PR addresses the problem by changing the cast to `bigint`