### PR TITLE
Keepalive and tcp timeout settings are supported

### DIFF
--- a/lib/message_store/postgres/settings.rb
+++ b/lib/message_store/postgres/settings.rb
@@ -22,7 +22,12 @@ module MessageStore
           :sslmode,
           :krbsrvname,
           :gsslib,
-          :service
+          :service,
+          :keepalives,
+          :keepalives_idle,
+          :keepalives_interval,
+          :keepalives_count,
+          :tcp_user_timeout
         ]
       end
 

--- a/settings/message_store_postgres.json
+++ b/settings/message_store_postgres.json
@@ -10,5 +10,10 @@
   "sslmode": null,
   "krbsrvname": null,
   "gsslib": null,
-  "service": null
+  "service": null,
+  "keepalives": null,
+  "keepalives_idle": null,
+  "keepalives_interval": null,
+  "keepalives_count": null,
+  "tcp_user_timeout": null
 }


### PR DESCRIPTION
The default timeout for broken TCP connections is 15 minutes. This allows setting a new timeout as well as configuring keepalives. These are standard pg settings: https://www.postgresql.org/docs/12/libpq-connect.html

As far as I can tell, they are not configurable via environment variable.