### PR TITLE
Session connection executed time is corrected

### DIFF
--- a/test/automated/session/connection_executed_time.rb
+++ b/test/automated/session/connection_executed_time.rb
@@ -3,7 +3,7 @@ require_relative '../automated_init'
 context "Session" do
   context "Connection Executed Time" do
     context "Before First Execution" do
-      session = Session.new
+      session = Session.build
 
       test "Executed time isn't set" do
         assert(session.executed_time.nil?)
@@ -11,10 +11,10 @@ context "Session" do
     end
 
     context "After Execution" do
-      session = Session.new
+      session = Session.build
+      Dependency::Substitute.(:clock, session)
 
       time = Controls::Time::Raw.example
-
       session.clock.now = time
 
       session.execute(';')


### PR DESCRIPTION
This test runs against the database named after the default user, which may or may not exist on macs with a typical homebrew installation. I chose to build the session and assign the clock rather than new the session up and set settings because it seemed more inline with the intention of the test.

Also, I was surprised that `Clock::Substitute.build` wasn't there.