### PR TITLE
Session closing is tested

### DIFF
--- a/lib/message_store/postgres/session.rb
+++ b/lib/message_store/postgres/session.rb
@@ -92,7 +92,7 @@ module MessageStore
 
       def close
         connection.close
-        connection = nil
+        self.connection = nil
       end
 
       def reset

--- a/test/automated/session/close.rb
+++ b/test/automated/session/close.rb
@@ -1,0 +1,46 @@
+require_relative "../automated_init"
+
+context "Session" do
+  context "Close" do
+    context "Session is Open" do
+      session = Session.build
+      session.open
+
+      assert(session.open?)
+
+      session.close
+
+      test "No longer connected" do
+        refute(session.connected?)
+      end
+
+      context "Connection Attribute" do
+        connection = session.connection
+
+        test "Not set" do
+          assert(connection.nil?)
+        end
+      end
+    end
+
+    context "Session is Closed" do
+      session = Session.build
+
+      refute(session.open?)
+
+      session.close
+
+      test "Not connected" do
+        refute(session.connected?)
+      end
+
+      context "Connection Attribute" do
+        connection = session.connection
+
+        test "Not set" do
+          assert(connection.nil?)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've made this a PR, and not a commit to master, because I'm not entirely confident in the test implementation.

Sessions have a predicate method that returns whether a session is connected or not: `connected?`. Using this method to determine if a session has closed it's connection is insufficient to prove that the session's `connection` attribute has been reset back no `nil`. So, I added a fairly mechanical test of the Session's connection attribute itself. It doesn't feel right because it seems like it's making an unnecessary observation of the session's internals. I can't really make heads or tails of this, so I'd like to go over it together collaboratively.